### PR TITLE
createUser の失敗時に関する部分を修正

### DIFF
--- a/src/api/api.types.ts
+++ b/src/api/api.types.ts
@@ -24,6 +24,7 @@ export type UserId = GeneralId;
  */
 export interface CreateUserResult extends ApiResult {
   userId?: UserId;
+  reason?: string,
 }
 
 /**

--- a/src/api/dummy.api.ts
+++ b/src/api/dummy.api.ts
@@ -23,6 +23,7 @@ export async function createUser() {
   const result: ApiTypes.CreateUserResult = isFailed(0.1)
     ? {
         succeeded: false,
+        reason: 'something wrong',
       }
     : {
         succeeded: true,


### PR DESCRIPTION
createUser は失敗時に reason を含む JSON を返すようです