### PR TITLE
generateRoute 関数で正常にエラーメッセージを生成できない問題を修正

### DIFF
--- a/src/api/manki.ts
+++ b/src/api/manki.ts
@@ -278,7 +278,7 @@ export async function generateRoute(userId: Api.UserId, subRoutes: Api.SubRoute[
                 return route;
             }, [] as Api.Route);
         } catch (msg) {
-            const message = (msg as string).replaceAll(/\d*/g, 'XXX');
+            const message = (msg as string).replaceAll(/\d+/g, 'XXX');
             switch (message) {
                 case 'Invalid request.':
                     return new Error('不正な API リクエストが発生しました。');


### PR DESCRIPTION
1 個以上の数字を検出しようとして 0 個以上の数字を検出していたようです